### PR TITLE
✨feat: 페이지네이션 기능 구현

### DIFF
--- a/src/main/java/com/example/umc7th/domain/article/controller/ArticleController.java
+++ b/src/main/java/com/example/umc7th/domain/article/controller/ArticleController.java
@@ -6,6 +6,7 @@ import com.example.umc7th.domain.article.service.command.ArticleCommandService;
 import com.example.umc7th.domain.article.service.query.ArticleQueryService;
 import com.example.umc7th.global.apiPayload.CustomResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,10 +34,14 @@ public class ArticleController {
                 .body(CustomResponse.onSuccess(HttpStatus.CREATED, responseDto));
     }
 
-    @Operation(summary = "전체 게시글 리스트 조회", description = "전체 게시글을 최신 순으로 조회합니다.")
+    @Operation(summary = "커서 기반 게시글 조회", description = "커서와 정렬 기준에 따라 게시글 목록을 조회합니다.")
     @GetMapping("")
-    public CustomResponse<ArticleResDto.ArticlePreviewListDto> getArticleList() {
-        ArticleResDto.ArticlePreviewListDto articles = articleQueryService.getArticleList();
+    public CustomResponse<ArticleResDto.ArticlePreviewListDto> getArticlesByCursor(
+            @Parameter(description = "다음 페이지 조회에 사용할 커서 값") @RequestParam(value = "cursor", required = false) Long cursor,
+            @Parameter(description = "한 페이지에 조회할 게시글 개수") @RequestParam(value = "offset", defaultValue = "10") int offset,
+            @Parameter(description = "정렬 기준 (예: id, createdAt, like)") @RequestParam(value = "sort", defaultValue = "id") String sort) {
+
+        ArticleResDto.ArticlePreviewListDto articles = articleQueryService.getArticlesByCursor(cursor, offset, sort);
         return CustomResponse.onSuccess(articles);
     }
 

--- a/src/main/java/com/example/umc7th/domain/article/converter/ArticleConverter.java
+++ b/src/main/java/com/example/umc7th/domain/article/converter/ArticleConverter.java
@@ -5,6 +5,7 @@ import com.example.umc7th.domain.article.dto.response.ArticleResDto;
 import com.example.umc7th.domain.article.entity.Article;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Slice;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -52,6 +53,19 @@ public class ArticleConverter {
         return ArticleResDto.ArticleLikeResponseDto.builder()
                 .id(article.getId())
                 .likeNum(article.getLikeNum())
+                .build();
+    }
+
+    // Slice -> ArticleCursorPaginationDto 변환 메서드
+    public static ArticleResDto.ArticlePreviewListDto toArticlePreviewListDto(Slice<Article> articles, Long nextCursor) {
+        List<ArticleResDto.ArticlePreviewDto> articleDtos = articles.stream()
+                .map(ArticleConverter::toArticlePreviewDto)
+                .toList();
+
+        return ArticleResDto.ArticlePreviewListDto.builder()
+                .articlePreviewDtoList(articleDtos)
+                .hasNext(articles.hasNext())
+                .cursor(nextCursor)
                 .build();
     }
 }

--- a/src/main/java/com/example/umc7th/domain/article/dto/response/ArticleResDto.java
+++ b/src/main/java/com/example/umc7th/domain/article/dto/response/ArticleResDto.java
@@ -27,7 +27,9 @@ public class ArticleResDto {
 
     @Builder
     public record ArticlePreviewListDto(
-            List<ArticlePreviewDto> articlePreviewDtoList
+            List<ArticlePreviewDto> articlePreviewDtoList,
+            Boolean hasNext,
+            Long cursor
     ){
     }
 

--- a/src/main/java/com/example/umc7th/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/com/example/umc7th/domain/article/repository/ArticleRepository.java
@@ -1,8 +1,26 @@
 package com.example.umc7th.domain.article.repository;
 
 import com.example.umc7th.domain.article.entity.Article;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface ArticleRepository extends JpaRepository<Article, Long> {
+    // id 기준 커서 페이지네이션
+    Slice<Article> findAllByIdLessThanOrderByIdDesc(Long id, Pageable pageable);
 
+    // 생성 날짜 기준 커서 페이지네이션
+    Slice<Article> findAllByCreatedAtLessThanOrderByCreatedAtDesc(LocalDateTime createdAt, Pageable pageable);
+
+    // 좋아요 수 기준 커서 페이지네이션 (좋아요 수와 id를 결합한 커서 사용)
+    @Query("SELECT a FROM Article a WHERE CONCAT(a.likeNum, a.id) < CONCAT(:likeNum, :id) ORDER BY a.likeNum DESC, a.id DESC")
+    Slice<Article> findByLikeNumAndIdCursor(@Param("likeNum") int likeNum, @Param("id") Long id, Pageable pageable);
+
+    // 제목에 특정 키워드를 포함하는 게시글 조회
+    List<Article> findByTitleContaining(String keyword);
 }

--- a/src/main/java/com/example/umc7th/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/com/example/umc7th/domain/article/repository/ArticleRepository.java
@@ -22,5 +22,5 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     Slice<Article> findByLikeNumAndIdCursor(@Param("likeNum") int likeNum, @Param("id") Long id, Pageable pageable);
 
     // 제목에 특정 키워드를 포함하는 게시글 조회
-    List<Article> findByTitleContaining(String keyword);
+    List<Article> findAllByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(String title, String content);
 }

--- a/src/main/java/com/example/umc7th/domain/article/service/query/ArticleQueryService.java
+++ b/src/main/java/com/example/umc7th/domain/article/service/query/ArticleQueryService.java
@@ -4,6 +4,6 @@ import com.example.umc7th.domain.article.dto.response.ArticleResDto;
 
 public interface ArticleQueryService {
 
-    ArticleResDto.ArticlePreviewListDto getArticleList();
     ArticleResDto.ArticlePreviewDto getArticle(Long articleId);
+    ArticleResDto.ArticlePreviewListDto getArticlesByCursor(Long cursor, int offset, String sort);
 }

--- a/src/main/java/com/example/umc7th/domain/article/service/query/ArticleQueryServiceImpl.java
+++ b/src/main/java/com/example/umc7th/domain/article/service/query/ArticleQueryServiceImpl.java
@@ -8,9 +8,15 @@ import com.example.umc7th.domain.article.exception.ArticleException;
 import com.example.umc7th.domain.article.repository.ArticleRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 
 @Slf4j
@@ -22,15 +28,73 @@ public class ArticleQueryServiceImpl implements ArticleQueryService {
     private final ArticleRepository articleRepository;
 
     @Override
-    public ArticleResDto.ArticlePreviewListDto getArticleList() {
-        List<Article> articles = articleRepository.findAll();
-        return ArticleConverter.toArticlePreviewListDto(articles);
-    }
-
-    @Override
     public ArticleResDto.ArticlePreviewDto getArticle(Long articleId) {
         Article article = articleRepository.findById(articleId)
                 .orElseThrow(()-> new ArticleException(ArticleErrorCode.ARTICLE_NOT_FOUND));
         return ArticleConverter.toArticlePreviewDto(article);
+    }
+
+    @Override
+    public ArticleResDto.ArticlePreviewListDto getArticlesByCursor(Long cursor, int offset, String sort) {
+        Pageable pageable = PageRequest.of(0, offset);
+        Slice<Article> articles;
+
+        // 정렬 기준에 따른 커서 페이지네이션 처리
+        switch (sort) {
+            case "createdAt":
+                articles = getArticlesByCreatedAtCursor(cursor, pageable);
+                break;
+            case "like":
+                articles = getArticlesByLikeNumCursor(cursor, pageable);
+                break;
+            default:
+                articles = getArticlesByIdCursor(cursor, pageable);
+        }
+
+        // 다음 커서 계산
+        Long nextCursor = calculateNextCursor(articles, sort);
+
+        // 변환하여 반환
+        return ArticleConverter.toArticlePreviewListDto(articles, nextCursor);
+    }
+
+    // ID 기준 커서 페이지네이션
+    private Slice<Article> getArticlesByIdCursor(Long cursor, Pageable pageable) {
+        Long cursorId = cursor != null ? cursor : Long.MAX_VALUE;
+        return articleRepository.findAllByIdLessThanOrderByIdDesc(cursorId, pageable);
+    }
+
+    // 생성 날짜 기준 커서 페이지네이션
+    private Slice<Article> getArticlesByCreatedAtCursor(Long cursor, Pageable pageable) {
+        LocalDateTime cursorCreatedAt = cursor != null
+                ? LocalDateTime.ofInstant(Instant.ofEpochMilli(cursor), ZoneId.systemDefault())
+                : LocalDateTime.now();
+        return articleRepository.findAllByCreatedAtLessThanOrderByCreatedAtDesc(cursorCreatedAt, pageable);
+    }
+
+    // 좋아요 수 기준 커서 페이지네이션
+    private Slice<Article> getArticlesByLikeNumCursor(Long cursor, Pageable pageable) {
+        int likeNum = cursor != null ? (int) (cursor >> 32) : Integer.MAX_VALUE;
+        Long id = cursor != null ? cursor & 0xFFFFFFFFL : Long.MAX_VALUE;
+        return articleRepository.findByLikeNumAndIdCursor(likeNum, id, pageable);
+    }
+
+    // 다음 커서 계산
+    private Long calculateNextCursor(Slice<Article> articles, String sort) {
+        if (!articles.hasNext()) {
+            return null; // 다음 페이지가 없으면 null 반환
+        }
+
+        Article lastArticle = articles.getContent().get(articles.getNumberOfElements() - 1);
+
+        // 정렬 기준에 따라 커서 값 계산
+        switch (sort) {
+            case "createdAt":
+                return lastArticle.getCreatedAt().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+            case "like":
+                return ((long) lastArticle.getLikeNum() << 32) | lastArticle.getId();
+            default:
+                return lastArticle.getId();
+        }
     }
 }

--- a/src/main/java/com/example/umc7th/domain/reply/controller/ReplyController.java
+++ b/src/main/java/com/example/umc7th/domain/reply/controller/ReplyController.java
@@ -6,6 +6,7 @@ import com.example.umc7th.domain.reply.service.command.ReplyCommandService;
 import com.example.umc7th.domain.reply.service.query.ReplyQueryService;
 import com.example.umc7th.global.apiPayload.CustomResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,11 +36,29 @@ public class ReplyController {
                 .body(CustomResponse.onSuccess(HttpStatus.CREATED, responseDto));
     }
 
+    @Operation(summary = "페이지 기반 댓글 조회", description = "게시글 ID에 따라 해당 게시글의 댓글 목록을 페이지 기반으로 조회합니다.")
+    @GetMapping("")
+    public CustomResponse<ReplyResDto.ReplyPreviewListDto> getRepliesByArticle(
+            @Parameter(description = "게시글 ID") @RequestParam Long articleId,
+            @Parameter(description = "페이지 번호") @RequestParam(value = "pageNo", defaultValue = "0") int pageNo,
+            @Parameter(description = "페이지당 댓글 수") @RequestParam(value = "pageSize", defaultValue = "10") int pageSize) {
+
+        ReplyResDto.ReplyPreviewListDto replies = replyQueryService.getRepliesByArticle(articleId, pageNo, pageSize);
+        return CustomResponse.onSuccess(replies);
+    }
+
     @Operation(summary = "게시글 별 댓글 조회", description = "articleId에 해당하는 게시글에 달린 모든 댓글을 조회합니다.")
     @GetMapping("/article/{articleId}")
     public CustomResponse<ReplyResDto.ReplyPreviewListDto> getRepliesByArticleId(@PathVariable Long articleId) {
         ReplyResDto.ReplyPreviewListDto replies = replyQueryService.getRepliesByArticle(articleId);
         return CustomResponse.onSuccess(replies);
+    }
+
+    @Operation(summary = "댓글 존재 여부 확인", description = "특정 게시글에 댓글이 있는지 확인합니다.")
+    @GetMapping("/{articleId}/has-replies")
+    public CustomResponse<String> hasReplies(@PathVariable Long articleId) {
+        boolean hasReplies = replyQueryService.hasReplies(articleId);
+        return CustomResponse.onSuccess("댓글 존재 여부 -> " + hasReplies);
     }
 
     @Operation(summary = "댓글 수정", description = "articleId에 해당하는 게시글의 특정 댓글(replyId)을 수정합니다.")

--- a/src/main/java/com/example/umc7th/domain/reply/controller/ReplyController.java
+++ b/src/main/java/com/example/umc7th/domain/reply/controller/ReplyController.java
@@ -40,10 +40,10 @@ public class ReplyController {
     @GetMapping("")
     public CustomResponse<ReplyResDto.ReplyPreviewListDto> getRepliesByArticle(
             @Parameter(description = "게시글 ID") @RequestParam Long articleId,
-            @Parameter(description = "페이지 번호") @RequestParam(value = "pageNo", defaultValue = "0") int pageNo,
+            @Parameter(description = "페이지 번호") @RequestParam(value = "pageNo", defaultValue = "1") int pageNo,
             @Parameter(description = "페이지당 댓글 수") @RequestParam(value = "pageSize", defaultValue = "10") int pageSize) {
 
-        ReplyResDto.ReplyPreviewListDto replies = replyQueryService.getRepliesByArticle(articleId, pageNo, pageSize);
+        ReplyResDto.ReplyPreviewListDto replies = replyQueryService.getRepliesByArticle(articleId, pageNo-1, pageSize);
         return CustomResponse.onSuccess(replies);
     }
 

--- a/src/main/java/com/example/umc7th/domain/reply/converter/ReplyConverter.java
+++ b/src/main/java/com/example/umc7th/domain/reply/converter/ReplyConverter.java
@@ -6,6 +6,7 @@ import com.example.umc7th.domain.reply.dto.response.ReplyResDto;
 import com.example.umc7th.domain.reply.entity.Reply;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -43,6 +44,21 @@ public class ReplyConverter {
     public static ReplyResDto.ReplyPreviewListDto toReplyPreviewListDto(List<Reply> replies) {
         return ReplyResDto.ReplyPreviewListDto.builder()
                 .replies(replies.stream().map(ReplyConverter::toReplyPreviewDTO).toList())
+                .build();
+    }
+
+    // Page 객체 -> ReplyPreviewListDto 변환 메서드
+    public static ReplyResDto.ReplyPreviewListDto toReplyPreviewListDto(Page<Reply> replyPage) {
+        List<ReplyResDto.ReplyPreviewDto> replyDtos = replyPage.getContent()
+                .stream()
+                .map(ReplyConverter::toReplyPreviewDTO)
+                .toList();
+
+        return ReplyResDto.ReplyPreviewListDto.builder()
+                .replies(replyDtos)
+                .numOfRows(replyPage.getNumberOfElements())
+                .pageNo(replyPage.getNumber())
+                .totalCount(replyPage.getTotalElements())
                 .build();
     }
 }

--- a/src/main/java/com/example/umc7th/domain/reply/converter/ReplyConverter.java
+++ b/src/main/java/com/example/umc7th/domain/reply/converter/ReplyConverter.java
@@ -58,7 +58,7 @@ public class ReplyConverter {
                 .replies(replyDtos)
                 .numOfRows(replyPage.getNumberOfElements())
                 .pageNo(replyPage.getNumber())
-                .totalCount(replyPage.getTotalElements())
+                .totalPage(replyPage.getTotalPages())
                 .build();
     }
 }

--- a/src/main/java/com/example/umc7th/domain/reply/converter/ReplyConverter.java
+++ b/src/main/java/com/example/umc7th/domain/reply/converter/ReplyConverter.java
@@ -57,7 +57,7 @@ public class ReplyConverter {
         return ReplyResDto.ReplyPreviewListDto.builder()
                 .replies(replyDtos)
                 .numOfRows(replyPage.getNumberOfElements())
-                .pageNo(replyPage.getNumber())
+                .pageNo(replyPage.getNumber()+1)
                 .totalPage(replyPage.getTotalPages())
                 .build();
     }

--- a/src/main/java/com/example/umc7th/domain/reply/dto/response/ReplyResDto.java
+++ b/src/main/java/com/example/umc7th/domain/reply/dto/response/ReplyResDto.java
@@ -26,7 +26,10 @@ public class ReplyResDto {
 
     @Builder
     public record ReplyPreviewListDto(
-            List<ReplyPreviewDto> replies
+            List<ReplyPreviewDto> replies,
+            int numOfRows,
+            int pageNo,
+            long totalCount
     ) {
     }
 }

--- a/src/main/java/com/example/umc7th/domain/reply/dto/response/ReplyResDto.java
+++ b/src/main/java/com/example/umc7th/domain/reply/dto/response/ReplyResDto.java
@@ -29,7 +29,7 @@ public class ReplyResDto {
             List<ReplyPreviewDto> replies,
             int numOfRows,
             int pageNo,
-            long totalCount
+            long totalPage
     ) {
     }
 }

--- a/src/main/java/com/example/umc7th/domain/reply/repository/ReplyRepository.java
+++ b/src/main/java/com/example/umc7th/domain/reply/repository/ReplyRepository.java
@@ -2,11 +2,16 @@ package com.example.umc7th.domain.reply.repository;
 
 import com.example.umc7th.domain.article.entity.Article;
 import com.example.umc7th.domain.reply.entity.Reply;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface ReplyRepository extends JpaRepository<Reply, Long> {
+    // 특정 게시글에 댓글이 존재하는지 확인하는 메서드
+    boolean existsByArticleId(Long articleId);
     List<Reply> findAllByArticle(Article article);
+    Page<Reply> findAllByArticleOrderByCreatedAtDesc(Article article, Pageable pageable);
 }

--- a/src/main/java/com/example/umc7th/domain/reply/service/query/ReplyQueryService.java
+++ b/src/main/java/com/example/umc7th/domain/reply/service/query/ReplyQueryService.java
@@ -5,4 +5,6 @@ import com.example.umc7th.domain.reply.dto.response.ReplyResDto;
 public interface ReplyQueryService {
 
     ReplyResDto.ReplyPreviewListDto getRepliesByArticle(Long articleId);
+    ReplyResDto.ReplyPreviewListDto getRepliesByArticle(Long articleId, int pageNo, int pageSize);
+    boolean hasReplies(Long articleId);
 }

--- a/src/main/java/com/example/umc7th/domain/reply/service/query/ReplyQueryServiceImpl.java
+++ b/src/main/java/com/example/umc7th/domain/reply/service/query/ReplyQueryServiceImpl.java
@@ -10,6 +10,9 @@ import com.example.umc7th.domain.reply.entity.Reply;
 import com.example.umc7th.domain.reply.repository.ReplyRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,5 +38,21 @@ public class ReplyQueryServiceImpl implements ReplyQueryService{
 
         //Converter를 통해 리스트 전체를 DTO로 변환 후 반환
         return ReplyConverter.toReplyPreviewListDto(replies);
+    }
+
+    @Override
+    public ReplyResDto.ReplyPreviewListDto getRepliesByArticle(Long articleId, int pageNo, int pageSize) {
+        Pageable pageable = PageRequest.of(pageNo, pageSize);
+        Article article = articleRepository.findById(articleId)
+                .orElseThrow(() -> new ArticleException(ArticleErrorCode.ARTICLE_NOT_FOUND));
+
+        Page<Reply> replies = replyRepository.findAllByArticleOrderByCreatedAtDesc(article, pageable);
+
+        return ReplyConverter.toReplyPreviewListDto(replies);
+    }
+
+    @Override
+    public boolean hasReplies(Long articleId) {
+        return replyRepository.existsByArticleId(articleId);
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ x ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #80 

## 📌 개요
- 게시글에 댓글이 있는지 확인하는 Query 생성 (ReplyRepository에서)

- 댓글 Offset 기반 페이지네이션 생성 날짜 순서로

- 게시글 Cursor 기반 페이지네이션 {id, 생성 날짜, 좋아요 수} 이 세가지 중 하나로 만들어주세요.
- 난이도는 id < 생성날짜 < 좋아요 수 입니다.
- id는 JPA Query Method로도 구현이 가능하지만 좋아요 수는 2주차에 나온 CONCAT을 사용하여 커서를 만들어주어야합니다. 
- 제목에 특정 문자를 포함하는 데이터를 찾는 Query 생성 (검색하는 기능을 구현하는 경우)

- 필수에서 3번을 2개 이상 구현하셨다면 정렬 기준을 담을 수 있는 하나의 컨트롤러에서 처리할 수 있도록 만들어주세요.

## 🔁 변경 사항
4d9a43c9ff526b89b6dc614e78fc57ea0eee565b

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [ x ] PR 템플릿에 맞추어 작성했어요.
- [ x ] 변경 내용에 대한 테스트를 진행했어요.
- [ x ] 프로그램이 정상적으로 동작해요.
- [ x ] PR에 적절한 라벨을 선택했어요.
- [ x ] 불필요한 코드는 삭제했어요.
