### PR TITLE
✨feat: 카카오 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,12 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+    // OAuth2 login
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    //Webflux
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/umc7th/controller/OAuth2Controller.java
+++ b/src/main/java/com/example/umc7th/controller/OAuth2Controller.java
@@ -1,0 +1,37 @@
+package com.example.umc7th.controller;
+
+import com.example.umc7th.dto.OAuth2Dto;
+import com.example.umc7th.dto.response.MemberResponseDto;
+import com.example.umc7th.global.apipayload.CustomResponse;
+import com.example.umc7th.global.apipayload.success.GeneralSuccessCode;
+import com.example.umc7th.service.command.OAuth2Service;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("")
+@Slf4j
+@Tag(name = "OAuth2 API", description = "OAuth2 관련 API")
+public class OAuth2Controller {
+
+    private final OAuth2Service oAuth2Service;
+
+    @GetMapping("/oauth2/callback/kakao")
+    public CustomResponse<MemberResponseDto.LoginResponseDto> loginWithKakao(@RequestParam("code") String code) {
+
+        String accessToken = oAuth2Service.getAccessTokenFromKakao(code);
+        log.info("code로 AT추출 완료 ");
+        OAuth2Dto.KakaoProfile userInfo = oAuth2Service.getUserInfo(accessToken);
+        log.info("AT로 userInfo 추출 완료 ");
+        MemberResponseDto.LoginResponseDto result = oAuth2Service.login(userInfo);
+        log.info("로그인 완료 ");
+
+        return CustomResponse.onSuccess(GeneralSuccessCode.SUCCESS_200, result);
+    }
+}

--- a/src/main/java/com/example/umc7th/dto/OAuth2Dto.java
+++ b/src/main/java/com/example/umc7th/dto/OAuth2Dto.java
@@ -1,0 +1,53 @@
+package com.example.umc7th.dto;
+
+import lombok.Getter;
+
+public class OAuth2Dto {
+
+    @Getter
+    public static class OAuth2TokenDto {
+        String token_type;
+        String access_token;
+        String refresh_token;
+        Long expires_in;
+        Long refresh_token_expires_in;
+        String scope;
+    }
+
+    @Getter
+    public static class KakaoProfile {
+        private Long id;
+        private String connected_at;
+        private Properties properties;
+        private KakaoAccount kakao_account;
+
+        @Getter
+        public class Properties {
+            private String nickname;
+            private String profile_image;
+            private String thumbnail_image;
+        }
+
+        @Getter
+        public class KakaoAccount {
+            private String email;
+            private Boolean is_email_verified;
+            private Boolean email_needs_agreement;
+            private Boolean has_email;
+            private Boolean profile_nickname_needs_agreement;
+            private Boolean profile_image_needs_agreement;
+            private Boolean email_needs_argument;
+            private Boolean is_email_valid;
+            private Profile profile;
+
+            @Getter
+            public class Profile {
+                private String nickname;
+                private String thumbnail_image_url;
+                private String profile_image_url;
+                private Boolean is_default_nickname;
+                private Boolean is_default_image;
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/umc7th/global/apipayload/code/MemberErrorCode.java
+++ b/src/main/java/com/example/umc7th/global/apipayload/code/MemberErrorCode.java
@@ -8,7 +8,9 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum MemberErrorCode implements BaseErrorCode{
 
-    NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404", "맴버를 찾을 수 없습니다.");
+    NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404_1", "맴버를 찾을 수 없습니다."),
+    OAUTH_TOKEN_FAIL(HttpStatus.BAD_REQUEST, "MEMBER400_1", "토큰 변환 실패"),
+    OAUTH_USER_INFO_FAIL(HttpStatus.NOT_FOUND, "MEMBER404_2", "사용자 정보 조회 실패");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/umc7th/global/jwt/config/SecurityConfig.java
+++ b/src/main/java/com/example/umc7th/global/jwt/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import jakarta.servlet.Filter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
@@ -35,7 +36,9 @@ public class SecurityConfig {
             "/swagger-resources/**",
             "/v3/api-docs/**",
             "/members/login",
-            "/members/register"
+            "/members/register",
+            "/oauth2/callback/kakao",
+            "/oauth2/authorization/kakao"
     };
 
     @Bean
@@ -53,6 +56,8 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 // httpBasic 비활성화
                 .httpBasic(HttpBasicConfigurer::disable)
+                // OAuth2 Login 설정을 default로 설정
+                .oauth2Login(Customizer.withDefaults())
                 // csrf 비활성화
                 .csrf(AbstractHttpConfigurer::disable)
                 // 인증 인가에 대한 예외처리
@@ -77,4 +82,5 @@ public class SecurityConfig {
     public BCryptPasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
+
 }

--- a/src/main/java/com/example/umc7th/service/command/OAuth2Service.java
+++ b/src/main/java/com/example/umc7th/service/command/OAuth2Service.java
@@ -1,0 +1,10 @@
+package com.example.umc7th.service.command;
+
+import com.example.umc7th.dto.OAuth2Dto;
+import com.example.umc7th.dto.response.MemberResponseDto;
+
+public interface OAuth2Service {
+    String getAccessTokenFromKakao(String code);
+    OAuth2Dto.KakaoProfile getUserInfo(String accessToken);
+    MemberResponseDto.LoginResponseDto login(OAuth2Dto.KakaoProfile userInfo);
+}

--- a/src/main/java/com/example/umc7th/service/command/OAuth2ServiceImpl.java
+++ b/src/main/java/com/example/umc7th/service/command/OAuth2ServiceImpl.java
@@ -1,0 +1,94 @@
+package com.example.umc7th.service.command;
+
+import com.example.umc7th.dto.OAuth2Dto;
+import com.example.umc7th.dto.response.MemberResponseDto;
+import com.example.umc7th.entity.Member;
+import com.example.umc7th.global.jwt.util.JwtProvider;
+import com.example.umc7th.repository.MemberRepository;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OAuth2ServiceImpl implements OAuth2Service{
+    @Value("${spring.security.oauth2.client.provider.kakao.token-uri}")
+    private String tokenURI; // Resource Server에 토큰 요청시 사용할 URI
+
+    @Value("${spring.security.oauth2.client.provider.kakao.user-info-uri}")
+    private String userInfoURI; // 사용자 정보 가져올 때 사용할 URI
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String clientId; // API KEY
+
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String redirectURI; // 설정한 Redirect uri
+
+    private final MemberRepository memberRepository;
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public String getAccessTokenFromKakao(String code) {
+        OAuth2Dto.OAuth2TokenDto oAuth2Dto = WebClient.create()
+                .post()
+                .uri(tokenURI, uriBuilder -> uriBuilder
+                        .queryParam("grant_type", "authorization_code")
+                        .queryParam("client_id", clientId)
+                        .queryParam("redirect_uri", redirectURI)   // 필수 파라미터
+                        .queryParam("code", code)
+                        .build())
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .retrieve()
+                .bodyToMono(OAuth2Dto.OAuth2TokenDto.class)
+                .doOnError(error -> log.error("Error occurred while getting token: ", error)) // 에러 로깅
+                .block();
+        log.info(oAuth2Dto.getAccess_token());
+
+        return oAuth2Dto.getAccess_token();
+
+    }
+
+    @Override
+    public OAuth2Dto.KakaoProfile getUserInfo(String accessToken) {
+        OAuth2Dto.KakaoProfile userInfo = WebClient.create(userInfoURI)
+                .get()
+                .uri(uriBuilder -> uriBuilder
+                        .build(true))
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken) // access token 인가
+                .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> Mono.error(new RuntimeException("Invalid Parameter")))
+                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> Mono.error(new RuntimeException("Internal Server Error")))
+                .bodyToMono(OAuth2Dto.KakaoProfile.class)
+                .block();
+
+        return userInfo;
+    }
+
+    @Override
+    public MemberResponseDto.LoginResponseDto login(OAuth2Dto.KakaoProfile userInfo) {
+        String email = userInfo.getKakao_account().getEmail();
+        // email을 찾고 있으면 member에 넣고 없으면 새로 만들어서 저장하고 넣는다.
+        Member member = memberRepository.findByEmail(email).orElse(
+                memberRepository.save(Member.builder()
+                        .email(email)
+                        .role("ROLE_USER")
+                        .build())
+        );
+        // TokenDTO로 변경해서 저번 주차에 구현한 JWT 형태로 반환
+        return MemberResponseDto.LoginResponseDto.builder()
+                .id(member.getId())
+                .accessToken(jwtProvider.createAccessToken(member))
+                .refreshToken(jwtProvider.createRefreshToken(member))
+                .build();
+    }
+
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #125 

## 📌 개요
- OAuth2ServiceImpl 함수 개선
- id 대신 email 적용
- 3가지 중 선택
   1. RestTemplate 대신 FeignClient 사용
   2. `RestTemplate 대신 WebClient 사용`  
   3. API 방식으로 요청 보내는 방식 말고 OAuth2-client 만 사용하는 방식

## 🔁 변경 사항
1830973b21c8833ca228530293a5c1b6dcf2b67c

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
